### PR TITLE
Added overwrite of existing screen manager

### DIFF
--- a/Assets/ScreenManager/ScreenManager.cs
+++ b/Assets/ScreenManager/ScreenManager.cs
@@ -77,7 +77,7 @@ namespace ScreenMgr {
         /// Initializes the class and fills the screen list with children ( executed automatically on Awake() )
         /// </summary>
         private void Initialize() {
-            ServiceLocator.Register<ScreenManager>(this);
+            ServiceLocator.Register<ScreenManager>(this, true);
             
             screenQueue = new List<BaseScreen>(50);
 


### PR DESCRIPTION
Added second parameter "true" to ServiceLocator.Register method call to enable overwrite of previously registered screen manager instance such that when changing scenes, we are not hit with the throw() for trying to re-register a screen manager.