### PR TITLE
Fix 2021.3.28 GUIStyle render issue

### DIFF
--- a/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
+++ b/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
@@ -291,7 +291,8 @@ namespace ScreenMgr.Editors
             GUILayout.BeginHorizontal(EditorStyles.toolbar);
             {
                 GUILayout.BeginHorizontal(GUI.skin.FindStyle("Toolbar"));
-                //GUILayout.FlexibleSpace();
+                
+                // Below is a result of Unity's typo in versions prior to 2021.3.28
                 toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSearchTextField");
                 if (toolbarSearchTextFieldStyle == null)
                     toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSeachTextField");

--- a/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
+++ b/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
@@ -24,11 +24,11 @@ namespace ScreenMgr.Editors
         private bool isDuplicated;
 
         // Support incorrect spelling of Unity GUI Style strings which were later fixed
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2021_3_28_OR_NEWER
         private const string toolbarSearchTextField = "ToolbarSearchTextField";
         private const string toolbarSearchCancelButton = "ToolbarSearchCancelButton";
 #else
-        private const string toolbarSearchTextField = "ToolbarSearchTextField";
+        private const string toolbarSearchTextField = "ToolbarSeachTextField";
         private const string toolbarSearchCancelButton = "ToolbarSeachCancelButton";
 #endif
 

--- a/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
+++ b/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
@@ -22,16 +22,8 @@ namespace ScreenMgr.Editors
         private int selectedId = -99;
         private double doubleClickTime = 0.3;
         private bool isDuplicated;
-
-        // Support incorrect spelling of Unity GUI Style strings which were later fixed
-        // in Unity 2021.3.28 and higher.
-#if UNITY_2021_3_OR_NEWER && !(UNITY_2021_3_27 || UNITY_2021_3_26 || UNITY_2021_3_25) // .. etc
-        private const string toolbarSearchTextField = "ToolbarSearchTextField";
-        private const string toolbarSearchCancelButton = "ToolbarSearchCancelButton";
-#else
-        private const string toolbarSearchTextField = "ToolbarSeachTextField";
-        private const string toolbarSearchCancelButton = "ToolbarSeachCancelButton";
-#endif
+        private GUIStyle toolbarSearchCancelButtonStyle;
+        private GUIStyle toolbarSearchTextFieldStyle;
 
         private BaseScreen[] TestingScreens
         {
@@ -300,8 +292,16 @@ namespace ScreenMgr.Editors
             {
                 GUILayout.BeginHorizontal(GUI.skin.FindStyle("Toolbar"));
                 //GUILayout.FlexibleSpace();
-                searchString = GUILayout.TextField(searchString, GUI.skin.FindStyle(toolbarSearchTextField));
-                if (GUILayout.Button("", GUI.skin.FindStyle(toolbarSearchCancelButton)))
+                toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSearchTextField");
+                if (toolbarSearchTextFieldStyle == null)
+                    toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSeachTextField");
+
+                toolbarSearchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
+                if (toolbarSearchCancelButtonStyle == null)
+                    toolbarSearchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
+
+                searchString = GUILayout.TextField(searchString, toolbarSearchTextFieldStyle);
+                if (GUILayout.Button("", toolbarSearchCancelButtonStyle))
                 {
                     // Remove focus if cleared
                     searchString = "";

--- a/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
+++ b/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
@@ -25,6 +25,18 @@ namespace ScreenMgr.Editors
         private GUIStyle toolbarSearchCancelButtonStyle;
         private GUIStyle toolbarSearchTextFieldStyle;
 
+        public void OnEnable()
+        {
+            // Below is a result of Unity's typo in versions prior to 2021.3.28
+            toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSearchTextField");
+            if (toolbarSearchTextFieldStyle == null)
+                toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSeachTextField");
+
+            toolbarSearchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
+            if (toolbarSearchCancelButtonStyle == null)
+                toolbarSearchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
+        }
+
         private BaseScreen[] TestingScreens
         {
             get
@@ -292,15 +304,6 @@ namespace ScreenMgr.Editors
             {
                 GUILayout.BeginHorizontal(GUI.skin.FindStyle("Toolbar"));
                 
-                // Below is a result of Unity's typo in versions prior to 2021.3.28
-                toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSearchTextField");
-                if (toolbarSearchTextFieldStyle == null)
-                    toolbarSearchTextFieldStyle = GUI.skin.FindStyle("ToolbarSeachTextField");
-
-                toolbarSearchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSearchCancelButton");
-                if (toolbarSearchCancelButtonStyle == null)
-                    toolbarSearchCancelButtonStyle = GUI.skin.FindStyle("ToolbarSeachCancelButton");
-
                 searchString = GUILayout.TextField(searchString, toolbarSearchTextFieldStyle);
                 if (GUILayout.Button("", toolbarSearchCancelButtonStyle))
                 {

--- a/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
+++ b/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
@@ -24,7 +24,8 @@ namespace ScreenMgr.Editors
         private bool isDuplicated;
 
         // Support incorrect spelling of Unity GUI Style strings which were later fixed
-#if UNITY_2021_3_28_OR_NEWER
+        // in Unity 2021.3.28 and higher.
+#if UNITY_2021_3_OR_NEWER && !(UNITY_2021_3_27 || UNITY_2021_3_26 || UNITY_2021_3_25) // .. etc
         private const string toolbarSearchTextField = "ToolbarSearchTextField";
         private const string toolbarSearchCancelButton = "ToolbarSearchCancelButton";
 #else
@@ -299,8 +300,6 @@ namespace ScreenMgr.Editors
             {
                 GUILayout.BeginHorizontal(GUI.skin.FindStyle("Toolbar"));
                 //GUILayout.FlexibleSpace();
-                searchString = GUILayout.TextField(searchString, GUI.skin.FindStyle("ToolbarSeachTextField")/*, GUILayout.MaxWidth(300)*/);
-                if (GUILayout.Button("", GUI.skin.FindStyle("ToolbarSeachCancelButton")))
                 searchString = GUILayout.TextField(searchString, GUI.skin.FindStyle(toolbarSearchTextField));
                 if (GUILayout.Button("", GUI.skin.FindStyle(toolbarSearchCancelButton)))
                 {

--- a/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
+++ b/Assets/ScreenManager/Editor/ScreenManagerEditor.cs
@@ -23,6 +23,15 @@ namespace ScreenMgr.Editors
         private double doubleClickTime = 0.3;
         private bool isDuplicated;
 
+        // Support incorrect spelling of Unity GUI Style strings which were later fixed
+#if UNITY_2021_3_OR_NEWER
+        private const string toolbarSearchTextField = "ToolbarSearchTextField";
+        private const string toolbarSearchCancelButton = "ToolbarSearchCancelButton";
+#else
+        private const string toolbarSearchTextField = "ToolbarSearchTextField";
+        private const string toolbarSearchCancelButton = "ToolbarSeachCancelButton";
+#endif
+
         private BaseScreen[] TestingScreens
         {
             get
@@ -292,6 +301,8 @@ namespace ScreenMgr.Editors
                 //GUILayout.FlexibleSpace();
                 searchString = GUILayout.TextField(searchString, GUI.skin.FindStyle("ToolbarSeachTextField")/*, GUILayout.MaxWidth(300)*/);
                 if (GUILayout.Button("", GUI.skin.FindStyle("ToolbarSeachCancelButton")))
+                searchString = GUILayout.TextField(searchString, GUI.skin.FindStyle(toolbarSearchTextField));
+                if (GUILayout.Button("", GUI.skin.FindStyle(toolbarSearchCancelButton)))
                 {
                     // Remove focus if cleared
                     searchString = "";


### PR DESCRIPTION
There was a typo fix with GUIStyle strings in Unity version 2021.3.28 and later meaning the ScreenManagerEditor inspector would not render correctly as elements were being set to null style.

Of course this was not documented by Unity in their [release notes](https://unity.com/releases/editor/whats-new/2021.3.28#release-notes) and probably should not have been part of a minor update on Unity's side.

I spent quite a bit of time tracking down the specific Unity minor version to which the 'typo fix' was introduced.

I'm not happy that the compiler directives for detecting a Unity minor version dosn't cover all versions, and didn't want to bloat the code with 27 directives; the directive #if UNITY_2021_3_28_OR_ABOVE is not recognised.

As you can see I reconsidered this limitation and moved away from directives and changed it to check for the GUIStyle.find resolves in null and if so then look up using an the 'corrected' spelling. Happy to change if you have a better idea.

PS Been using this for several years on most of my Unity projects, so more than happy to contribute :)
